### PR TITLE
Updated Task ACK to avoid 500

### DIFF
--- a/condu/conductor.py
+++ b/condu/conductor.py
@@ -185,9 +185,11 @@ class TaskClient(BaseClient):
         url = self.makeUrl('{}/ack', taskId)
         params = {}
         params['workerid'] = workerid
-        headers = {'Accept': 'text/plain'}
+        # This is strange, but sending text/plain will result in a 500 from
+        # Conductor. application/json works, but a string is returned back.
+        headers = {'Accept': 'application/json'}
         value = self.post(url, params, None, headers)
-        return value == 'true'
+        return value
 
     def getTasksInQueue(self, taskName):
         url = self.makeUrl('queue/{}', taskName)


### PR DESCRIPTION
- Sending a header of text/plain would return in a 500 when ack'ing a
task. Accepting application/json will result in desired behavior.