### PR TITLE
Add timeouts to worker tasks to prevent them to continue to run even after conductor server has terminated the task.

### DIFF
--- a/condu/condu.py
+++ b/condu/condu.py
@@ -4,6 +4,7 @@ import time
 from threading import Event
 import sys
 import gc
+import os
 
 from condu.objects import MetaTask, TaskDef, WorkflowDef
 from condu.conductor import WFClientMgr
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class Condu(WFClientMgr):
-    def __init__(self, server_url: str, hostname: str = socket.gethostname(), signum=signal.SIGTERM):
+    def __init__(self, server_url: str, hostname: str = socket.gethostname(), signum=signal.SIGTERM, grace_period=10):
         super().__init__(server_url)
         self.tasks = {}
         self.hostname = hostname
@@ -32,7 +33,12 @@ class Condu(WFClientMgr):
         self._child_process = None
         # save worker task received by pipe from child process / worker
         self._worker_task_from_child = None
+        # duration of time in seconds that a intermediate process waits for a child process
+        self._grace_period = grace_period
         # ----------------------
+
+    # ------------------------- ******************* ------------------------
+    # ------------------    Worker Task execution UTILS   ------------------
 
     # used to terminate current _condu_task if the worker process has any
     def __terminate_task(self):
@@ -42,7 +48,7 @@ class Condu(WFClientMgr):
                 condu_task.status = 'FAILED'
                 condu_task.append_to_logs("Task FAILED due to worker shutdown.")
                 self.task_client.updateTask(condu_task.get_dict())
-                logger.error('Task set as FAILED due to worker shutdown.', exc_info=True)
+                logger.error('Task set as FAILED due to worker shutdown.')
         except Exception:
             # If we can't update worker task we are sorry but we really need to shutdown the process.
             pass
@@ -52,6 +58,17 @@ class Condu(WFClientMgr):
     def __intermediate_signal_handler(self):
         try:
             self._child_process.terminate()
+            self._child_process.join(self._grace_period)
+            if self._child_process.is_alive():
+                os.kill(self._child_process.pid, signal.SIGKILL)
+                self._child_process.join()
+
+                if self._worker_task_from_child is not None:
+                    condu_task = MetaTask(self._worker_task_from_child)
+                    condu_task.status = 'FAILED'
+                    condu_task.append_to_logs("Task FAILED due to worker shutdown.")
+                    self.task_client.updateTask(condu_task.get_dict())
+                    logger.error('Task set as FAILED due to worker shutdown.')
         except Exception:
             # If we can't terminate a daemon child process it will terminate by himself if isn't terminated yet
             pass
@@ -62,6 +79,8 @@ class Condu(WFClientMgr):
         try:
             for process in self._processes_list:
                 process.terminate()
+            for process in self._processes_list:
+                process.join()
                 logger.info("Intermediate Process terminated")
         except TypeError as terr:
             # It means the handler is not callable or that it doesn't take 1 required parameter
@@ -73,16 +92,6 @@ class Condu(WFClientMgr):
             logger.error(exc)
         finally:
             self._shutdown_event.set()
-            sys.exit(0)
-
-    # ------------------ *************** ------------------
-    # ------------------ Task Management ------------------
-
-    def remove_task(self, task_name: str):
-        self.tasks.pop(task_name)
-
-    def put_task(self, task_name: str, func):
-        self.tasks[task_name] = func
 
     def __signal_definitions(self, child_signal_handler, signum):
         # sets the handler supplied
@@ -91,11 +100,11 @@ class Condu(WFClientMgr):
             self._child_signal_handler = child_signal_handler
         signal.signal(self._signum, self.__parent_signal_handler)
 
-    def __intermediate_process(self, task, exec_function, polling_interval):
+    def __intermediate_process(self, task, exec_function, polling_interval, timeout=None):
         def child_process_shutdown(signum, frame):
             self._intermediate_signal_handler()
 
-        # Sets the handler for SIGTERM in the child process. SIGTERM can be triggered in parent process.
+        # Sets the handler for SIGTERM in the child process. SIGTERM can be triggered in parent process using terminate method.
         signal.signal(signal.SIGTERM, child_process_shutdown)
 
         process_name = mp.current_process().name
@@ -103,15 +112,30 @@ class Condu(WFClientMgr):
         while True:
             logger.info("{} is going to create a child process (worker).".format(process_name))
             conn1, conn2 = mp.Pipe(duplex=False)
-            self._child_process = mp.Process(target=self.__start_task, args=(task, exec_function, polling_interval, conn2))
+            self._child_process = mp.Process(target=self.__start_task, args=(task, exec_function, conn2, polling_interval))
             self._child_process.daemon = True
             self._child_process.start()
             # This needs to be closed in parent process, so that we can have a EOFError raised when child closes the pipe.
             conn2.close()
             self._worker_task_from_child = None
             try:
-                while True:
-                    self._worker_task_from_child = conn1.recv()
+                self._worker_task_from_child = conn1.recv()
+                if timeout is not None:
+                    self._child_process.join(timeout)
+                    if self._child_process.is_alive():
+                        raise TimeoutError("Task execution terminated because task took longer than {} seconds to complete.".format(timeout))
+                else:
+                    self._child_process.join()
+            except TimeoutError as te:
+                logger.error("{} received TimeoutError.".format(process_name))
+                if self._worker_task_from_child is not None:
+                    os.kill(self._child_process.pid, signal.SIGKILL)
+                    condu_task = MetaTask(self._worker_task_from_child)
+                    condu_task.status = 'FAILED'
+                    condu_task.append_to_logs("Task FAILED. {}".format(te))
+                    self.task_client.updateTask(condu_task.get_dict())
+                    logger.error('Task set as FAILED due to Timeout Error.', exc_info=True)
+                    gc.collect()
             except EOFError as eof:
                 logger.error("{} received EOFError.".format(process_name))
                 if self._worker_task_from_child is not None:
@@ -134,7 +158,7 @@ class Condu(WFClientMgr):
             self._child_process.join()
 
     def start_tasks(self, polling_interval: float = 0.2, processes: int = 1, child_signal_handler: callable = None,
-                    signum: int = None):
+                    signum: int = None, timeout=None):
 
         """ Blocking method, creates <processes> child processes for each task; each process polls and executes the task in
         with at least the interval of <polling_interval> seconds. A signal can also be sent to gracefully unblock
@@ -146,41 +170,42 @@ class Condu(WFClientMgr):
             exec_function = self.tasks[task]
             for i in range(processes):
                 # create intermediate process to launch child process to process condu task as discussed in issue #001
-                process = mp.Process(target=self.__intermediate_process, args=(task, exec_function, polling_interval))
+                process = mp.Process(target=self.__intermediate_process, args=(task, exec_function, polling_interval, timeout))
                 process.start()
                 self._processes_list.append(process)
         # This is a blocking call that blocks this thread/process (main one) until shutdown_event.set() is called
         self._shutdown_event.wait()
 
-    def __start_task(self, task_name, exec_function, polling_interval, pipe):
+    def __start_task(self, task_name, exec_function, pipe, polling_interval):
         def child_process_shutdown(signum, frame):
             self._child_signal_handler()
 
         # Sets the handler for SIGTERM in the child process. SIGTERM can be triggered in parent process.
         signal.signal(signal.SIGTERM, child_process_shutdown)
 
-        while True:
-            self.poll_and_execute_task(task_name, exec_function, pipe)
-            time.sleep(polling_interval)
+        self.poll_and_execute_task(task_name, exec_function, pipe, polling_interval)
 
-    def poll_and_execute_task(self, task_name, exec_function, pipe):
+    def poll_and_execute_task(self, task_name, exec_function, pipe, polling_interval):
         # Insert the polling cycle here
-        logger.debug('Polling for [' + task_name + '] as [' + self.hostname + ']')
-        self._conductor_task = self.task_client.pollForTask(task_name, self.hostname)
-        if self._conductor_task is not None:
-            # Send conductor task through pipe before start working on it
-            if self.task_client.ackTask(self._conductor_task['taskId'], self.hostname):
-                pipe.send(self._conductor_task)
-                self.__execute_task(self._conductor_task, exec_function)
-                # Send None when finish working on conductor task
-                pipe.send(None)
+        while True:
+            logger.debug('Polling for [' + task_name + '] as [' + self.hostname + ']')
+            self._conductor_task = self.task_client.pollForTask(task_name, self.hostname)
+            if self._conductor_task is not None:
+                # Send conductor task through pipe before start working on it
+                if self.task_client.ackTask(self._conductor_task['taskId'], self.hostname):
+                    pipe.send(self._conductor_task)
+                    self.__execute_task(self._conductor_task, exec_function)
+                    break
+            time.sleep(polling_interval)
 
     def __execute_task(self, conductor_task, exec_function):
         """ Executes the exec_function and updates the task status in conductor """
         condu_task = MetaTask(conductor_task)
         try:
+            logger.info("Going to execute task {} with id {}.".format(condu_task.referenceTaskName, condu_task.taskId))
             exec_function(condu_task)
         except Exception as err:
+            logger.info("Exception raised during execution of task {} with id {}.". format(condu_task.referenceTaskName, condu_task.taskId))
             condu_task.status = 'FAILED'
             condu_task.append_to_logs(str(err))
             logger.error('Task set as FAILED', exc_info=True)
@@ -188,6 +213,15 @@ class Condu(WFClientMgr):
         self.task_client.updateTask(condu_task.get_dict())
         logger.info("[" + condu_task.status + "] [" + condu_task.referenceTaskName + "]-[" + condu_task.taskId + "]-[" +
                     condu_task.status + "] in the workflow - [" + condu_task.workflowInstanceId + "]")
+
+    # ------------------ *************** ------------------
+    # ------------------ Task Management ------------------
+
+    def remove_task(self, task_name: str):
+        self.tasks.pop(task_name)
+
+    def put_task(self, task_name: str, func):
+        self.tasks[task_name] = func
 
     # ------------------ ******************* ------------------
     # ------------------ Workflow Management ------------------

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='2.0.0b07',  # Required
+    version='2.0.0b10',  # Required
     # ==============================================================
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,0 +1,174 @@
+from condu import condu
+from time import sleep
+import responses
+import socket
+import multiprocessing as mp
+
+fake_conductor_uri = "http://localhost:8080/api"
+fake_task_blueprint = {
+   "taskType": "tmp_task",
+   "status": "SCHEDULED",
+   "inputData": {
+      "foo": "bar"
+   },
+   "referenceTaskName": "tmp_task2",
+   "retryCount": 0,
+   "seq": 2,
+   "pollCount": 0,
+   "taskDefName": "tmp_task",
+   "scheduledTime": 1556531815953,
+   "startTime": 0,
+   "endTime": 0,
+   "updateTime": 1556531815961,
+   "startDelayInSeconds": 0,
+   "retried": False,
+   "executed": False,
+   "callbackFromWorker": True,
+   "responseTimeoutSeconds": 3600,
+   "workflowInstanceId": "83e930cb-4891-40f8-b8e5-8e7ef1b616d5",
+   "workflowType": "5cc1cf44d14d34000b498a4d",
+   "taskId": "9eef76e7-b3f4-4c68-86e4-7df63a192898",
+   "callbackAfterSeconds": 0,
+   "workflowTask": {
+      "name": "tmp_task",
+      "taskReferenceName": "tmp_task2",
+      "description": "tmp_task",
+      "inputParameters": {
+         "foo": "bar"
+      },
+      "type": "SIMPLE",
+      "startDelay": 0,
+      "optional": False,
+      "taskDefinition": {
+         "createTime": 1556132886211,
+         "name": "tmp_task",
+         "description": "tmp_task",
+         "retryCount": 2,
+         "timeoutSeconds": 0,
+         "inputKeys": [
+            "foo"
+         ],
+         "outputKeys": [
+
+         ],
+         "timeoutPolicy": "TIME_OUT_WF",
+         "retryLogic": "FIXED",
+         "retryDelaySeconds": 0,
+         "responseTimeoutSeconds": 3600,
+         "rateLimitPerFrequency": 0,
+         "rateLimitFrequencyInSeconds": 1
+      }
+   },
+   "rateLimitPerFrequency": 0,
+   "rateLimitFrequencyInSeconds": 0,
+   "taskStatus": "SCHEDULED",
+   "queueWaitTime": 0,
+   "taskDefinition": {
+      "present": True
+   },
+   "logs": []
+}
+
+
+def tmp_task_deadlock(task):
+    while True:
+        pass
+
+
+def tmp_task(task):
+    sleep(20)
+    task.status = "COMPLETED"
+
+
+def call_start_tasks_with_timeout(conductor_client, timeout):
+    conductor_client.start_tasks(processes=1, polling_interval=1, timeout=timeout)
+
+
+@responses.activate
+def test_timeout_10(mocker):
+    # mocks response to pollForTask
+    responses.add(method="GET",
+                  url=fake_conductor_uri + "/tasks/poll/tmp_task" + "?workerid=" + socket.gethostname(),
+                  status=200,
+                  json=fake_task_blueprint,
+                  content_type="application/json")
+    # mocks response to ackTask
+    responses.add(method="POST",
+                  url=fake_conductor_uri + "/tasks/9eef76e7-b3f4-4c68-86e4-7df63a192898/ack" + "?workerid=" + socket.gethostname(),
+                  status=200,
+                  json=True,
+                  content_type="application/json")
+    # mock response to updateTask
+    responses.add(method="POST",
+                  url=fake_conductor_uri + "/tasks/",
+                  status=200,
+                  content_type="text/plain")
+
+    conductor_client = condu.Condu(fake_conductor_uri)
+    conductor_client.put_task("tmp_task", tmp_task)
+
+    child_process = mp.Process(target=call_start_tasks_with_timeout, args=(conductor_client, 10,))
+    child_process.start()
+    child_process.join(60)
+    child_process.terminate()
+    # TODO: Make asserts. IF the logs present FAILED tasks this test doesn't detected errors
+
+
+@responses.activate
+def test_timeout_30():
+    # mocks response to pollForTask
+    responses.add(method="GET",
+                  url=fake_conductor_uri + "/tasks/poll/tmp_task" + "?workerid=" + socket.gethostname(),
+                  status=200,
+                  json=fake_task_blueprint,
+                  content_type="application/json")
+    # mocks response to ackTask
+    responses.add(method="POST",
+                  url=fake_conductor_uri + "/tasks/9eef76e7-b3f4-4c68-86e4-7df63a192898/ack" + "?workerid=" + socket.gethostname(),
+                  status=200,
+                  json=True,
+                  content_type="application/json")
+    # mock response to updateTask
+    responses.add(method="POST",
+                  url=fake_conductor_uri + "/tasks/",
+                  status=200,
+                  content_type="text/plain")
+
+    conductor_client = condu.Condu(fake_conductor_uri)
+    conductor_client.put_task("tmp_task", tmp_task)
+
+    child_process = mp.Process(target=call_start_tasks_with_timeout, args=(conductor_client, 30,))
+    child_process.start()
+    child_process.join(60)
+    child_process.terminate()
+    # TODO: Make asserts. IF the logs present COMPLETED tasks this test doesn't detected errors
+
+
+@responses.activate
+def test_without_timeout():
+    # mocks response to pollForTask
+    responses.add(method="GET",
+                  url=fake_conductor_uri + "/tasks/poll/tmp_task" + "?workerid=" + socket.gethostname(),
+                  status=200,
+                  json=fake_task_blueprint,
+                  content_type="application/json")
+    # mocks response to ackTask
+    responses.add(method="POST",
+                  url=fake_conductor_uri + "/tasks/9eef76e7-b3f4-4c68-86e4-7df63a192898/ack" + "?workerid=" + socket.gethostname(),
+                  status=200,
+                  json=True,
+                  content_type="application/json")
+    # mock response to updateTask
+    responses.add(method="POST",
+                  url=fake_conductor_uri + "/tasks/",
+                  status=200,
+                  content_type="text/plain")
+
+    conductor_client = condu.Condu(fake_conductor_uri)
+    conductor_client.put_task("tmp_task", tmp_task)
+
+    child_process = mp.Process(target=call_start_tasks_with_timeout, args=(conductor_client, None,))
+    child_process.start()
+    child_process.join(60)
+    child_process.terminate()
+    # TODO: Make asserts. IF the logs present COMPLETED tasks this test doesn't detected errors


### PR DESCRIPTION
In Conductor server you can set timeouts for the worker tasks, but if you want to execute the task in the worker with the same timeout you need to encapsulate it in a process that you can terminate when the timeout is attained, otherwise the worker continues to execute even after conductor server has already terminated the task.

With this commit, we can run worker tasks with a timeout defined in the conductor client. The timeouts are optional. If a user doesn't specify a timeout while creating the client, no timeouts are applied and the task runs as before (without timeouts). 

TODO: In the future we can change the code to apply the timeouts to individual tasks, instead of applying a general timeout to all the tasks managed by the condu client.